### PR TITLE
Added provider source address

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    mongodbatlas = {
+      source = "mongodb/mongodbatlas"
+      version = "1.4.6"
+    }
+  }
+}
+
 provider "mongodbatlas" {
   public_key = "<YOUR PUBLIC KEY HERE>"
   private_key  = "<YOUR PRIVATE KEY HERE>"


### PR DESCRIPTION
Added source address since Terraform is unable to retrieve automatically.

Overcomes the following errror : 

```
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/mongodbatlas: provider registry
│ registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/mongodbatlas
```